### PR TITLE
fix empty contentMetadata element on purge

### DIFF
--- a/bin/virtual-merge
+++ b/bin/virtual-merge
@@ -38,7 +38,7 @@ class VirtualMergeTool
   end
 
   def run(purge = false)
-    @parent.contentMetadata.content = '<contentMetadata/>' if purge
+    @parent.contentMetadata.content = "<contentMetadata objectId='#{@parent.pid}' type='image'/>" if purge
     @child_druids.each do |child|
       begin
         merge(Dor::Item.find(child))


### PR DESCRIPTION
This PR fixes the `--purge` option by added the `objectId` and `type` attributes to the `contentMetadata` element.