### PR TITLE
Add Honeybadger to boot.rb

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -2,6 +2,7 @@ require 'bundler/setup'
 
 require 'optparse'
 require 'logger'
+require 'honeybadger'
 
 ENV_LOG = Logger.new(File.expand_path(File.dirname(__FILE__) + '/../log/solrizer.log'))
 


### PR DESCRIPTION
The last update to add Honeybadger neglected to require it in the Ruby scripts - this is a fix for that oversight.