### PR TITLE
bin/virtual-merge: we don't need to notify Honeybadger

### DIFF
--- a/bin/virtual-merge
+++ b/bin/virtual-merge
@@ -44,7 +44,8 @@ class VirtualMergeTool
         merge(Dor::Item.find(child))
       rescue => e
         @logger.error "#{e}: #{e.backtrace.join("\n")}"
-        Honeybadger.notify(e)
+        # logging output is sufficient for a script
+        # Honeybadger.notify(e)
       end
     end
     @parent.save


### PR DESCRIPTION
Working on #17.  Since this is currently a script run at the command line, no need to report errors to Honeybadger.  Let's see if this addresses the remaining problems from this embarrassingly old issue.

Error is:
```
[lyberadmin@sul-lyberservices-prod current]$ bundle exec bin/virtual-merge --purge --environment=production  druid:ds623xk2719 druid:cf088nn0221 druid:cw049rd7067 druid:rz597dq8213 druid:dg148hz5693 druid:qf251yh6066
DEPRECATION WARNING: Dor::Config -- solrizer configuration is deprecated. Please use solr instead. (called from <top (required)> at /home/lyberadmin/dor-utils/releases/20190805145213/config/environments/production.rb:3)
bundler: failed to load command: bin/virtual-merge (bin/virtual-merge) # <------  LOOK AT THIS
NameError: uninitialized constant VirtualMergeTool::Honeybadger
  bin/virtual-merge:47:in `rescue in block in run'
  bin/virtual-merge:43:in `block in run'
  bin/virtual-merge:42:in `each'
  bin/virtual-merge:42:in `run'
  bin/virtual-merge:113:in `<top (required)>'
```
