### PR TITLE
Require honeybadger

### DIFF
--- a/bin/virtual-merge
+++ b/bin/virtual-merge
@@ -12,7 +12,7 @@
 require 'logger'
 require 'optparse'
 require 'yaml'
-
+require 'honeybadger'
 require 'dor-services'
 
 #


### PR DESCRIPTION
Honeybadger was added in https://github.com/sul-dlss/dor-utils/commit/f4a77338159e44bcfb4b112cc21b91b1a0107e0a#diff-254cb3dcb463d03f48135e13b55803c5 but it was never required.